### PR TITLE
EXTRAS works

### DIFF
--- a/default.env
+++ b/default.env
@@ -11,6 +11,7 @@ SNAPSHOT=
 
 LOG_LEVEL=info
 L2GETH_DOCKER_TAG=scroll-v5.8.33
+MPT_NODE=true
 
 # External Docker network if using ext-network.yml
 DOCKER_EXT_NETWORK=traefik_default
@@ -29,4 +30,4 @@ RPC_PORT=8545
 WS_PORT=8546
 
 # Used by mantled update - please do not adjust
-ENV_VERSION=3
+ENV_VERSION=4

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${MPT_NODE}" = "true" ]; then
+  __mpt="--scroll-mpt"
+else
+  __mpt=""
+fi
+
+exec "$@" ${__mpt} ${EXTRAS}

--- a/scroll.yml
+++ b/scroll.yml
@@ -26,14 +26,18 @@ services:
     stop_grace_period: 5m
     volumes:
       - scroll-data:/var/lib/l2geth
+      - ./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
     environment:
       RUST_LOG: ${LOG_LEVEL}
       CHAIN_ID: "534352"
+      MPT_NODE: ${MPT_NODE}
+      EXTRAS: ${EXTRAS}
     depends_on:
       scroll-init:
         condition: service_completed_successfully
     <<: *logging
     entrypoint:
+      - docker-entrypoint.sh
       - geth
       - --datadir
       - /var/lib/l2geth
@@ -63,7 +67,6 @@ services:
       - --da.blob.beaconnode
       - ${L1_BEACON}
       - --rollup.verify
-      - --scroll-mpt
     labels:
       - traefik.enable=true
       - traefik.http.routers.${RPC_HOST:-scroll}.service=${RPC_HOST:-scroll}


### PR DESCRIPTION
With a bind-mounted entrypoint. Also make MPT configurable.

If bind-mount was a mistake, put entrypoint into locally built image as usual for X Docker